### PR TITLE
add annotate, freehand roi, and eraser, organize toolbar, highlight submenu tools

### DIFF
--- a/extensions/ohif-cornerstone-extension/src/toolbarModule.js
+++ b/extensions/ohif-cornerstone-extension/src/toolbarModule.js
@@ -36,24 +36,6 @@ const definitions = [
     commandOptions: { toolName: 'StackScroll' },
   },
   {
-    id: 'Zoom',
-    label: 'Zoom',
-    icon: 'search-plus',
-    //
-    type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-    commandName: 'setToolActive',
-    commandOptions: { toolName: 'Zoom' },
-  },
-  {
-    id: 'Wwwc',
-    label: 'Levels',
-    icon: 'level',
-    //
-    type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-    commandName: 'setToolActive',
-    commandOptions: { toolName: 'Wwwc' },
-  },
-  {
     id: 'Pan',
     label: 'Pan',
     icon: 'arrows',
@@ -63,45 +45,78 @@ const definitions = [
     commandOptions: { toolName: 'Pan' },
   },
   {
-    id: 'Length',
-    label: 'Length',
+    id: 'Zoom',
+    label: 'Zoom',
+    icon: 'search-plus',
+    //
+    type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
+    commandName: 'setToolActive',
+    commandOptions: { toolName: 'Zoom' },
+  },
+  {
+    id: 'DrawTools',
+    label: 'Draw',
     icon: 'measure-temp',
-    //
-    type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-    commandName: 'setToolActive',
-    commandOptions: { toolName: 'Length' },
+    buttons: [
+      {
+        id: 'ArrowAnnotate',
+        label: 'Arrow Annotate',
+        icon: 'edit',
+        //
+        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
+        commandName: 'setToolActive',
+        commandOptions: { toolName: 'ArrowAnnotate' },
+      },
+      {
+        id: 'FreehandRoi',
+        label: 'Freehand',
+        icon: 'liver',
+        //
+        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
+        commandName: 'setToolActive',
+        commandOptions: { toolName: 'FreehandMouse' },
+      },
+      {
+        id: 'Length',
+        label: 'Length',
+        icon: 'measure-temp',
+        //
+        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
+        commandName: 'setToolActive',
+        commandOptions: { toolName: 'Length' },
+      },
+      {
+        id: 'Angle',
+        label: 'Angle',
+        icon: 'angle-left',
+        //
+        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
+        commandName: 'setToolActive',
+        commandOptions: { toolName: 'Angle' },
+      },
+      {
+        id: 'Eraser',
+        label: 'Eraser',
+        icon: 'square-o',
+        //
+        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
+        commandName: 'setToolActive',
+        commandOptions: { toolName: 'Eraser' },
+      },
+      {
+        id: 'Clear',
+        label: 'Delete All',
+        icon: 'trash',
+        //
+        type: TOOLBAR_BUTTON_TYPES.COMMAND,
+        commandName: 'clearAnnotations',
+      },
+    ],
   },
   {
-    id: 'Angle',
-    label: 'Angle',
-    icon: 'angle-left',
-    //
-    type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-    commandName: 'setToolActive',
-    commandOptions: { toolName: 'Angle' },
-  },
-  {
-    id: 'Reset',
-    label: 'Reset',
-    icon: 'reset',
-    //
-    type: TOOLBAR_BUTTON_TYPES.COMMAND,
-    commandName: 'resetViewport',
-  },
-  {
-    id: 'Cine',
-    label: 'CINE',
-    icon: 'youtube',
-    //
-    type: TOOLBAR_BUTTON_TYPES.BUILT_IN,
-    options: {
-      behavior: 'CINE',
-    },
-  },
-  {
-    id: 'More',
-    label: 'More',
-    icon: 'ellipse-circle',
+    id: 'ViewTools',
+    label: 'Viewport',
+    icon: 'search-plus',
     buttons: [
       {
         id: 'Magnify',
@@ -111,50 +126,6 @@ const definitions = [
         type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
         commandName: 'setToolActive',
         commandOptions: { toolName: 'Magnify' },
-      },
-      {
-        id: 'WwwcRegion',
-        label: 'ROI Window',
-        icon: 'stop',
-        //
-        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-        commandName: 'setToolActive',
-        commandOptions: { toolName: 'WwwcRegion' },
-      },
-      {
-        id: 'DragProbe',
-        label: 'Probe',
-        icon: 'dot-circle',
-        //
-        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-        commandName: 'setToolActive',
-        commandOptions: { toolName: 'DragProbe' },
-      },
-      {
-        id: 'EllipticalRoi',
-        label: 'Ellipse',
-        icon: 'circle-o',
-        //
-        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-        commandName: 'setToolActive',
-        commandOptions: { toolName: 'EllipticalRoi' },
-      },
-      {
-        id: 'RectangleRoi',
-        label: 'Rectangle',
-        icon: 'square-o',
-        //
-        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
-        commandName: 'setToolActive',
-        commandOptions: { toolName: 'RectangleRoi' },
-      },
-      {
-        id: 'Invert',
-        label: 'Invert',
-        icon: 'adjust',
-        //
-        type: TOOLBAR_BUTTON_TYPES.COMMAND,
-        commandName: 'invertViewport',
       },
       {
         id: 'RotateRight',
@@ -181,14 +152,31 @@ const definitions = [
         commandName: 'flipViewportVertical',
       },
       {
-        id: 'Clear',
-        label: 'Clear',
-        icon: 'trash',
+        id: 'Wwwc',
+        label: 'Levels',
+        icon: 'level',
+        //
+        type: TOOLBAR_BUTTON_TYPES.SET_TOOL_ACTIVE,
+        commandName: 'setToolActive',
+        commandOptions: { toolName: 'Wwwc' },
+      },
+      {
+        id: 'Invert',
+        label: 'Invert',
+        icon: 'adjust',
         //
         type: TOOLBAR_BUTTON_TYPES.COMMAND,
-        commandName: 'clearAnnotations',
+        commandName: 'invertViewport',
       },
     ],
+  },
+  {
+    id: 'Reset',
+    label: 'Reset Viewport',
+    icon: 'reset',
+    //
+    type: TOOLBAR_BUTTON_TYPES.COMMAND,
+    commandName: 'resetViewport',
   },
 ];
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.5",
-    "@ohif/extension-cornerstone": "0.0.40",
+    "@ohif/extension-cornerstone": "file:.yalc/@ohif/extension-cornerstone",
     "@ohif/extension-dicom-html": "0.0.3",
     "@ohif/extension-dicom-microscopy": "0.0.9",
     "@ohif/extension-dicom-pdf": "0.0.7",

--- a/src/connectedComponents/ToolbarRow.js
+++ b/src/connectedComponents/ToolbarRow.js
@@ -10,7 +10,7 @@ import { commandsManager, extensionManager } from './../App.js';
 
 import ConnectedCineDialog from './ConnectedCineDialog';
 import ConnectedLayoutButton from './ConnectedLayoutButton';
-import ConnectedPluginSwitch from './ConnectedPluginSwitch.js';
+// import ConnectedPluginSwitch from './ConnectedPluginSwitch.js';
 import { MODULE_TYPES } from 'ohif-core';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
@@ -128,7 +128,7 @@ class ToolbarRow extends Component {
           </div>
           {buttonComponents}
           <ConnectedLayoutButton />
-          <ConnectedPluginSwitch />
+          {/* <ConnectedPluginSwitch /> */}
           <div
             className="pull-right m-t-1 rm-x-1"
             style={{ marginLeft: 'auto' }}

--- a/src/initCornerstoneTools.js
+++ b/src/initCornerstoneTools.js
@@ -20,8 +20,8 @@ export default function(configuration = {}) {
 
   // Tool styles/colors
   cornerstoneTools.toolStyle.setToolWidth(2);
-  cornerstoneTools.toolColors.setToolColor('rgb(255, 255, 0)');
-  cornerstoneTools.toolColors.setActiveColor('rgb(0, 255, 0)');
+  cornerstoneTools.toolColors.setToolColor('magenta');
+  cornerstoneTools.toolColors.setActiveColor('cyan');
 
   cornerstoneTools.store.state.touchProximity = 40;
 }

--- a/src/setupTools.js
+++ b/src/setupTools.js
@@ -154,11 +154,6 @@ export default function setupTools(store) {
     {
       name: 'Eraser',
       mouseButtonMasks: [1],
-      props: {
-        configuration: {
-          getMeasurementLocationCallback: toolLabellingFlowCallback,
-        },
-      },
     },
     { name: 'Pan', mouseButtonMasks: [1, 4] },
     { name: 'Zoom', mouseButtonMasks: [1, 2] },

--- a/src/setupTools.js
+++ b/src/setupTools.js
@@ -142,15 +142,6 @@ function getResetLabellingAndContextMenu(store) {
 export default function setupTools(store) {
   const toolLabellingFlowCallback = getToolLabellingFlowCallback(store);
   const availableTools = [
-    {
-      name: 'ArrowAnnotate',
-      props: {
-        configuration: {
-          getMeasurementLocationCallback: toolLabellingFlowCallback,
-        },
-      },
-    },
-    { name: 'Eraser' },
     { name: 'Pan', mouseButtonMasks: [1, 4] },
     { name: 'Zoom', mouseButtonMasks: [1, 2] },
     { name: 'Wwwc', mouseButtonMasks: [1] },

--- a/src/setupTools.js
+++ b/src/setupTools.js
@@ -142,6 +142,24 @@ function getResetLabellingAndContextMenu(store) {
 export default function setupTools(store) {
   const toolLabellingFlowCallback = getToolLabellingFlowCallback(store);
   const availableTools = [
+    {
+      name: 'ArrowAnnotate',
+      mouseButtonMasks: [1],
+      props: {
+        configuration: {
+          getMeasurementLocationCallback: toolLabellingFlowCallback,
+        },
+      },
+    },
+    {
+      name: 'Eraser',
+      mouseButtonMasks: [1],
+      props: {
+        configuration: {
+          getMeasurementLocationCallback: toolLabellingFlowCallback,
+        },
+      },
+    },
     { name: 'Pan', mouseButtonMasks: [1, 4] },
     { name: 'Zoom', mouseButtonMasks: [1, 2] },
     { name: 'Wwwc', mouseButtonMasks: [1] },

--- a/src/setupTools.js
+++ b/src/setupTools.js
@@ -144,17 +144,13 @@ export default function setupTools(store) {
   const availableTools = [
     {
       name: 'ArrowAnnotate',
-      mouseButtonMasks: [1],
       props: {
         configuration: {
           getMeasurementLocationCallback: toolLabellingFlowCallback,
         },
       },
     },
-    {
-      name: 'Eraser',
-      mouseButtonMasks: [1],
-    },
+    { name: 'Eraser' },
     { name: 'Pan', mouseButtonMasks: [1, 4] },
     { name: 'Zoom', mouseButtonMasks: [1, 2] },
     { name: 'Wwwc', mouseButtonMasks: [1] },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,10 +1237,8 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@ohif/extension-cornerstone@0.0.40":
-  version "0.0.40"
-  resolved "https://registry.yarnpkg.com/@ohif/extension-cornerstone/-/extension-cornerstone-0.0.40.tgz#44414b8f92994e14ae8f9bef5ff22c6e551825a7"
-  integrity sha512-HTx9cjIm395Y/nTckTHkkiWACHT6seYahvpvP8n4BTOZqXyHsMxN9T5VdrvUwskRD1deKQXzXUep7KI3V7ic3Q==
+"@ohif/extension-cornerstone@file:.yalc/@ohif/extension-cornerstone":
+  version "0.0.41-33a51054"
   dependencies:
     "@babel/runtime" "^7.2.0"
     classnames "^2.2.6"


### PR DESCRIPTION
Handful of changes here. We can merge these into the sitka dev branch but using this temporary branch for now.

Toolbar
---
![image](https://user-images.githubusercontent.com/1167291/61255729-10448580-a727-11e9-8841-cd4fbe0c51f6.png)

Draw submenu
---
![image](https://user-images.githubusercontent.com/1167291/61255737-1a668400-a727-11e9-8fb2-650d9751ce1a.png)

Viewport submenu
---
![image](https://user-images.githubusercontent.com/1167291/61255755-294d3680-a727-11e9-85d8-3ee9dc4b653e.png)

Submenu tool active
---
![image](https://user-images.githubusercontent.com/1167291/61255760-323e0800-a727-11e9-9505-f5291d23c6b3.png)

Draw color changes (Cyan is the color while performing the act of drawing, Magenta is what it looks like afterwards)
---
![image](https://user-images.githubusercontent.com/1167291/61255781-4aae2280-a727-11e9-914d-7a8adef79b7c.png)

Contributes to https://github.com/trustsitka/sitka/issues/3403