### PR TITLE
Add cancelActiveDraw action and command

### DIFF
--- a/extensions/ohif-cornerstone-extension/src/commandsModule.js
+++ b/extensions/ohif-cornerstone-extension/src/commandsModule.js
@@ -91,59 +91,30 @@ const actions = {
     console.warn('updateDisplaySet: ', direction);
   },
   clearAnnotations: ({ viewports }) => {
-    const element = _getActiveViewportEnabledElement(
-      viewports.viewportSpecificData,
-      viewports.activeViewportIndex
-    );
-    if (!element) {
-      return;
-    }
+    const enabledElement = _getEnabledElement(viewports);
+    const enabledElementToolState = _getElementToolState(enabledElement);
 
-    const enabledElement = cornerstone.getEnabledElement(element);
-    if (!enabledElement || !enabledElement.image) {
-      return;
-    }
+    Object.entries(enabledElementToolState)
+      .forEach(([toolType, toolState]) => {
+        const { data } = toolState;
 
-    const {
-      toolState,
-    } = cornerstoneTools.globalImageIdSpecificToolStateManager;
-    if (
-      !toolState ||
-      toolState.hasOwnProperty(enabledElement.image.imageId) === false
-    ) {
-      return;
-    }
-
-    const imageIdToolState = toolState[enabledElement.image.imageId];
-
-    const measurementsToRemove = [];
-
-    Object.keys(imageIdToolState).forEach(toolType => {
-      const { data } = imageIdToolState[toolType];
-
-      data.forEach(measurementData => {
-        const { _id, lesionNamingNumber, measurementNumber } = measurementData;
-        if (!_id) {
-          return;
-        }
-
-        measurementsToRemove.push({
-          toolType,
-          _id,
-          lesionNamingNumber,
-          measurementNumber,
-        });
+        data
+          .filter(({ _id }) => _id)
+          .forEach(data => _removeMeasurementData(toolType, data));
       });
-    });
+  },
+  cancelActiveDraw: ({ viewports }) => {
+    const enabledElement = _getEnabledElement(viewports);
+    const enabledElementToolState = _getElementToolState(enabledElement);
 
-    measurementsToRemove.forEach(measurementData => {
-      OHIF.measurements.MeasurementHandlers.onRemoved({
-        detail: {
-          toolType: measurementData.toolType,
-          measurementData,
-        },
+    Object.entries(enabledElementToolState)
+      .forEach(([toolType, toolState]) => {
+        const { data } = toolState;
+
+        data
+          .filter(({ _id, active }) => _id && active)
+          .forEach(data => _removeMeasurementData(toolType, data));
       });
-    });
   },
 };
 
@@ -217,6 +188,11 @@ const definitions = {
     storeContexts: [],
     options: {},
   },
+  cancelActiveDraw: {
+    commandFn: actions.cancelActiveDraw,
+    storeContexts: ['viewports'],
+    options: {},
+  }
 };
 
 /**
@@ -226,6 +202,50 @@ const definitions = {
 function _getActiveViewportEnabledElement(viewports, activeIndex) {
   const activeViewport = viewports[activeIndex] || {};
   return activeViewport.dom;
+}
+
+function _getEnabledElement(viewports, activeIndex) {
+  const element = _getActiveViewportEnabledElement(
+    viewports.viewportSpecificData,
+    viewports.activeViewportIndex
+  );
+  if (!element) {
+    return null;
+  }
+
+  const enabledElement = cornerstone.getEnabledElement(element);
+  if (!enabledElement || !enabledElement.image) {
+    return null;
+  }
+
+  return enabledElement;
+}
+
+function _getElementToolState(element) {
+  const { toolState } = cornerstoneTools.globalImageIdSpecificToolStateManager;
+  const { imageId } = element.image;
+
+  if (toolState && toolState.hasOwnProperty(imageId)) {
+    return toolState[imageId];
+  }
+
+  return null;
+}
+
+function _removeMeasurementData(toolType, data) {
+  const { _id, active, lesionNamingNumber, measurementNumber } = data;
+
+  OHIF.measurements.MeasurementHandlers.onRemoved({
+    detail: {
+      toolType,
+      measurementData: {
+        _id,
+        active,
+        lesionNamingNumber,
+        measurementNumber,
+      }
+    },
+  });
 }
 
 export default {

--- a/extensions/ohif-cornerstone-extension/src/commandsModule.js
+++ b/extensions/ohif-cornerstone-extension/src/commandsModule.js
@@ -99,7 +99,7 @@ const actions = {
         const { data } = toolState;
 
         data
-          .filter(({ _id }) => _id)
+          .filter(({ _id }) => !!_id)
           .forEach(data => _removeMeasurementData(toolType, data));
       });
   },
@@ -112,7 +112,7 @@ const actions = {
         const { data } = toolState;
 
         data
-          .filter(({ _id, active }) => _id && active)
+          .filter(({ _id, active }) => !!_id && !!active)
           .forEach(data => _removeMeasurementData(toolType, data));
       });
   },
@@ -225,7 +225,7 @@ function _getElementToolState(element) {
   const { toolState } = cornerstoneTools.globalImageIdSpecificToolStateManager;
   const { imageId } = element.image;
 
-  if (toolState && toolState.hasOwnProperty(imageId)) {
+  if (toolState && Object.prototype.hasOwnProperty.call(toolState, imageId)) {
     return toolState[imageId];
   }
 

--- a/extensions/ohif-cornerstone-extension/src/commandsModule.js
+++ b/extensions/ohif-cornerstone-extension/src/commandsModule.js
@@ -94,27 +94,35 @@ const actions = {
     const enabledElement = _getEnabledElement(viewports);
     const enabledElementToolState = _getElementToolState(enabledElement);
 
-    Object.entries(enabledElementToolState)
-      .forEach(([toolType, toolState]) => {
-        const { data } = toolState;
+    if (enabledElementToolState) {
+      Object.entries(enabledElementToolState).forEach(
+        ([toolType, toolState]) => {
+          const { data } = toolState;
 
-        data
-          .filter(({ _id }) => !!_id)
-          .forEach(data => _removeMeasurementData(toolType, data));
-      });
+          data
+            .filter(({ _id }) => !!_id)
+            .forEach(data => _removeMeasurementData(toolType, data));
+        }
+      );
+    }
   },
   cancelActiveDraw: ({ viewports }) => {
     const enabledElement = _getEnabledElement(viewports);
     const enabledElementToolState = _getElementToolState(enabledElement);
 
-    Object.entries(enabledElementToolState)
-      .forEach(([toolType, toolState]) => {
-        const { data } = toolState;
+    if (enabledElementToolState) {
+      Object.entries(enabledElementToolState).forEach(
+        ([toolType, toolState]) => {
+          const { data } = toolState;
 
-        data
-          .filter(({ _id, active }) => !!_id && !!active)
-          .forEach(data => _removeMeasurementData(toolType, data));
-      });
+          data
+            .filter(({ _id, active }) => !!_id && !!active)
+            .forEach(data => _removeMeasurementData(toolType, data));
+        }
+      );
+
+      cornerstoneTools.cancelDrawing();
+    }
   },
 };
 
@@ -192,7 +200,7 @@ const definitions = {
     commandFn: actions.cancelActiveDraw,
     storeContexts: ['viewports'],
     options: {},
-  }
+  },
 };
 
 /**
@@ -243,7 +251,7 @@ function _removeMeasurementData(toolType, data) {
         active,
         lesionNamingNumber,
         measurementNumber,
-      }
+      },
     },
   });
 }

--- a/public/config/default.js
+++ b/public/config/default.js
@@ -70,5 +70,6 @@ window.config = {
     },
     // ~ Cornerstone Tools
     { commandName: 'setZoomTool', label: 'Zoom', keys: ['z'] },
+    { commandName: 'cancelActiveDraw', label: 'Cancel', keys: ['escape'] },
   ],
 };


### PR DESCRIPTION
This is a PR to add the escape to cancel behavior that we had in the old viewer. It's not implemented the same, but should be good. Some notes:

* Deleting all the active data doesn't stop the draw - this doesn't seem to cause any exceptions, just seems to swallow the next mouse click and then start drawing again
* This also deletes the data from the tool under the mouse on hover - apparently those data points are marked as active as well

PR at OHIF to discuss  whether we should push this in to cornerstoneTools https://github.com/OHIF/Viewers/pull/676

Contributes to https://github.com/trustsitka/sitka/issues/3417