### PR TITLE
fix zoom reset by updating dependency

### DIFF
--- a/extensions/ohif-cornerstone-extension/package.json
+++ b/extensions/ohif-cornerstone-extension/package.json
@@ -39,7 +39,7 @@
     "@babel/runtime": "^7.2.0",
     "classnames": "^2.2.6",
     "lodash.throttle": "^4.1.1",
-    "react-cornerstone-viewport": "0.1.30"
+    "react-cornerstone-viewport": "0.1.32"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "classnames": "^2.2.6",
     "cornerstone-core": "^2.2.8",
     "cornerstone-math": "^0.1.8",
-    "cornerstone-tools": "^3.15.1",
+    "cornerstone-tools": "file:.yalc/cornerstone-tools",
     "cornerstone-wado-image-loader": "^2.2.3",
     "dcmjs": "^0.4.7",
     "dicom-parser": "^1.8.3",


### PR DESCRIPTION
also check in switch to cornerstone-tools yalc dependency

We'll be able to replace this with the version we get next upgrade to Viewers.